### PR TITLE
Update command

### DIFF
--- a/tutorial/pipeline_features.md
+++ b/tutorial/pipeline_features.md
@@ -83,7 +83,7 @@ Following features will be demonstrated:
 
 6. Version setup under **git**
 
-        git add ./dummy *.dvc
+        git add ./dummy .dvc .mlvtools
         git commit -m 'Dummy pipeline setup'
 
 


### PR DESCRIPTION
Currently running the command `git add ./dummy *.dvc` gives the error:

    fatal: pathspec '*.dvc' did not match any files

because upon `dvc init`, a `.dvc` folder is created but not any files with extension `*.dvc`.
I also added the `.mlvtools` file that is created by the `make dummy-conf` step.